### PR TITLE
Update CI to Supported Versions

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -45,7 +45,7 @@ jobs:
             redis_*.orig.tar.gz
 
   build-binary-package:
-    runs-on: ubuntu-latest
+    runs-on: ${{ contains(matrix.arch, 'arm') && 'ubuntu24-arm64-2-8' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -57,11 +57,21 @@ jobs:
     - uses: actions/checkout@v4
     - name: Determine build architecture
       run: |
-          if [ ${{ matrix.arch }} = "i386" ]; then
-              BUILD_ARCH=i386
-          else
-              BUILD_ARCH=amd64
-          fi
+          case ${{ matrix.arch }} in
+            i386)
+                BUILD_ARCH=i386
+                ;;
+            arm64)
+                BUILD_ARCH=arm64
+                ;;
+            armhf)
+                BUILD_ARCH=armhf
+                ;;
+            *) 
+                BUILD_ARCH=amd64
+                ;;
+          esac
+        
           echo "BUILD_ARCH=${BUILD_ARCH}" >> $GITHUB_ENV
     - name: Setup APT Signing key
       run: |

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
           sudo apt-get update && \
@@ -35,7 +35,7 @@ jobs:
           sed -i "s/@RELEASE@/${{ matrix.dist }}/g" redis-${VERSION}/debian/changelog
           ( cd redis-${VERSION} && dpkg-buildpackage -S )
     - name: Upload source package artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: source-${{ matrix.dist }}
         path: |
@@ -52,7 +52,7 @@ jobs:
         exclude: ${{ fromJSON(vars.BUILD_EXCLUDE) }}
     needs: build-source-package
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Determine build architecture
       run: |
           if [ ${{ matrix.arch }} = "i386" ]; then
@@ -76,7 +76,7 @@ jobs:
     - name: Prepare sbuild environment
       run: sudo ./setup_sbuild.sh ${{ matrix.dist }} ${{ env.BUILD_ARCH }}
     - name: Get source package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: source-${{ matrix.dist }}
     - name: Build binary package
@@ -87,7 +87,7 @@ jobs:
             --build ${{ env.BUILD_ARCH }} \
             --dist ${{ matrix.dist }} *.dsc
     - name: Upload binary package artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: binary-${{ matrix.dist }}-${{ matrix.arch }}
         path: |
@@ -104,7 +104,7 @@ jobs:
     container: ${{ matrix.image }}
     steps:
     - name: Get binary packages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
     - name: Install packages
       run: |
         apt-get update
@@ -132,7 +132,7 @@ jobs:
       env:
         APT_SIGNING_KEY: ${{ secrets.APT_SIGNING_KEY }}
     - name: Get binary packages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -12,6 +12,7 @@ jobs:
   build-source-package:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
     steps:
@@ -46,6 +47,7 @@ jobs:
   build-binary-package:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
         arch: ${{ fromJSON(vars.BUILD_ARCHS) }}
@@ -99,6 +101,7 @@ jobs:
     env:
       ARCH: amd64
     strategy:
+      fail-fast: false
       matrix:
         image: ${{ fromJSON(vars.SMOKE_TEST_IMAGES) }}
     container: ${{ matrix.image }}

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - release/**
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build-source-package:
@@ -17,7 +20,7 @@ jobs:
       run: |
           sudo apt-get update && \
           sudo apt-get install \
-            debhelper dput tcl-tls libsystemd-dev pkg-config
+            debhelper dput tcl-tls libsystemd-dev pkg-config build-essential
     - name: Determine version
       run: |
           VERSION=$(head -1 debian/changelog | sed 's/^.*([0-9]*:*\([0-9.]*\)-.*$/\1/')
@@ -116,6 +119,7 @@ jobs:
         echo ping | redis-cli -p 26379
 
   upload-packages:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release/*'
     env:
       DEB_S3_VERSION: "0.11.3"
     runs-on: ubuntu-latest

--- a/setup_sbuild.sh
+++ b/setup_sbuild.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 if [ $# != 2 ]; then
     echo "Please use: setup_build.sh [dist] [arch]"
@@ -13,11 +12,18 @@ else
     disttype="debian"
 fi
 
-# Determine base apt repository URL based on type of distribution.
+if [ "$dist" = "focal" ]; then
+     ubuntu_ports="/ubuntu-ports"
+fi
+# Determine base apt repository URL based on type of distribution and architecture.
 case "$disttype" in
     ubuntu)
-        url=http://archive.ubuntu.com/ubuntu
-        ;;
+        if [ "$arch" = "arm64" ]; then
+            url=http://ports.ubuntu.com/ubuntu-ports
+        else
+            url=http://archive.ubuntu.com/ubuntu
+        fi
+         ;;
     debian)
         url=http://deb.debian.org/debian
         ;;
@@ -31,12 +37,34 @@ sbuild-createchroot \
     ${dist} `mktemp -d` ${url}
 
 # Ubuntu has the main and ports repositories on different URLs, so we need to
-# properly set up /etc/apt/sources.list to make cross compilation work.
+# properly set up /etc/apt/sources.list to make cross compilation work
+# and enable multi-architecture support inside a chroot environment
 if [ "$disttype" = "ubuntu" ]; then
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture i386
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture armhf
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture arm64
+    # Update /etc/apt/sources.list for cross-compilation (Ubuntu)
     cat <<__END__ | schroot -c source:${dist}-${arch}-sbuild -d / -- tee /etc/apt/sources.list
 deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu ${dist} main universe
 deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu ${dist}-updates main universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com ${dist} main universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com ${dist}-updates main universe
+deb [arch=armhf,arm64] http://ports.ubuntu.com${ubuntu_ports} ${dist} main universe
+deb [arch=armhf,arm64] http://ports.ubuntu.com${ubuntu_ports} ${dist}-updates main universe
 __END__
+
+elif [ "$disttype" = "debian" ]; then
+#   enable multi-architecture support inside a chroot environment
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture i386
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture armhf
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture arm64
+    # Update /etc/apt/sources.list for cross-compilation  (Debian)
+    cat <<__END__ | schroot -c source:${dist}-${arch}-sbuild -d / -- tee /etc/apt/sources.list
+deb [arch=amd64,i386,armhf,arm64] http://deb.debian.org/debian ${dist} main contrib non-free non-free-firmware
+deb [arch=amd64,i386,armhf,arm64] http://deb.debian.org/debian ${dist}-updates main contrib non-free non-free-firmware
+deb [arch=amd64,i386,armhf,arm64] http://deb.debian.org/debian-security ${dist}-security main contrib non-free non-free-firmware
+__END__
+fi
+if [ "$dist" = "focal" ]; then
+    # Install gcc-10 and g++-10 which are required in case of Ubuntu Focal to support Ranges library, introduced in C++20
+    schroot -c source:${dist}-${arch}-sbuild -d / -- bash -c "apt update && apt remove -y gcc-9 g++-9 gcc-9-base && apt upgrade -yqq && apt install -y gcc build-essential gcc-10 g++-10 clang-format clang lcov openssl"
+    schroot -c source:${dist}-${arch}-sbuild -d / -- bash -c "[ -f /usr/bin/gcc-10 ] && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10|| echo 'gcc-10 installation failed'"
 fi

--- a/setup_sbuild.sh
+++ b/setup_sbuild.sh
@@ -18,7 +18,7 @@ fi
 # Determine base apt repository URL based on type of distribution and architecture.
 case "$disttype" in
     ubuntu)
-        if [ "$arch" = "arm64" ]; then
+        if [ "$arch" = "arm64" ] || [ "$arch" = "armhf" ]; then
             url=http://ports.ubuntu.com/ubuntu-ports
         else
             url=http://archive.ubuntu.com/ubuntu


### PR DESCRIPTION
- Update our GitHub Actions to the latest major versions.
- Update our `setup_sbuild.sh` script to support the updated Ubuntu 24.04 GH runners.
- Enable CI to run on PRs.