### PR TITLE
RED-159764 scheduled unstable workflow trigger

### DIFF
--- a/.github/workflows/nightly-unstable-package.yaml
+++ b/.github/workflows/nightly-unstable-package.yaml
@@ -1,0 +1,10 @@
+name: Nightly Unstable Build and Package
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # Run at 1:00 AM UTC every day
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  call-unstable-build:
+    uses: redis/redis-debian/.github/workflows/apt.yml@unstable


### PR DESCRIPTION
Create a new workflow that will trigger the build and package on an unstable branch, nightly.