### PR TITLE
Redis 8.2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+redis (6:8.2.1-1rl1~@RELEASE@1) @RELEASE@; urgency=low
+
+  * Redis 8.2.1: https://github.com/redis/redis/releases/tag/8.2.1
+
+ -- Redis Team <redis@redis.io>  Sun, 18 Aug 2025 12:00:00 +0300
+
 redis (6:8.2.0-1rl1~@RELEASE@1) @RELEASE@; urgency=low
 
   * Redis 8.2.0: https://github.com/redis/redis/releases/tag/8.2.0


### PR DESCRIPTION
Bump image version to 8.2.1 following the established pattern from previous releases.

This PR updates the debian/changelog to add a new entry for Redis 8.2.1, maintaining consistency with the versioning scheme used in this repository.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author