### PR TITLE
debian: add llvm and libclang-dev to Build-Depends (fix nightly noble/arm64 clang-sys)

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -147,7 +147,10 @@ jobs:
                 --bucket ${{ env.APT_S3_BUCKET }} \
                 --s3-region ${{ env.APT_S3_REGION }} \
                 --codename $dist \
+                --suite $dist \
+                --origin packages.redis.io \
                 --preserve-versions \
+                --lock \
                 --fail-if-exists \
                 --sign \
                 --prefix deb \

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -4,20 +4,24 @@ on:
   push:
     branches:
     - release/**
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build-source-package:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
           sudo apt-get update && \
           sudo apt-get install \
-            debhelper dput tcl-tls libsystemd-dev pkg-config
+            debhelper dput tcl-tls libsystemd-dev pkg-config build-essential
     - name: Determine version
       run: |
           VERSION=$(head -1 debian/changelog | sed 's/^.*([0-9]*:*\([0-9.]*\)-.*$/\1/')
@@ -32,7 +36,7 @@ jobs:
           sed -i "s/@RELEASE@/${{ matrix.dist }}/g" redis-${VERSION}/debian/changelog
           ( cd redis-${VERSION} && dpkg-buildpackage -S )
     - name: Upload source package artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: source-${{ matrix.dist }}
         path: |
@@ -41,22 +45,33 @@ jobs:
             redis_*.orig.tar.gz
 
   build-binary-package:
-    runs-on: ubuntu-latest
+    runs-on: ${{ contains(matrix.arch, 'arm') && 'ubuntu24-arm64-2-8' || 'ubuntu-latest' }}
     strategy:
+      fail-fast: false
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
         arch: ${{ fromJSON(vars.BUILD_ARCHS) }}
         exclude: ${{ fromJSON(vars.BUILD_EXCLUDE) }}
     needs: build-source-package
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Determine build architecture
       run: |
-          if [ ${{ matrix.arch }} = "i386" ]; then
-              BUILD_ARCH=i386
-          else
-              BUILD_ARCH=amd64
-          fi
+          case ${{ matrix.arch }} in
+            i386)
+                BUILD_ARCH=i386
+                ;;
+            arm64)
+                BUILD_ARCH=arm64
+                ;;
+            armhf)
+                BUILD_ARCH=armhf
+                ;;
+            *) 
+                BUILD_ARCH=amd64
+                ;;
+          esac
+        
           echo "BUILD_ARCH=${BUILD_ARCH}" >> $GITHUB_ENV
     - name: Setup APT Signing key
       run: |
@@ -73,7 +88,7 @@ jobs:
     - name: Prepare sbuild environment
       run: sudo ./setup_sbuild.sh ${{ matrix.dist }} ${{ env.BUILD_ARCH }}
     - name: Get source package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: source-${{ matrix.dist }}
     - name: Build binary package
@@ -84,7 +99,7 @@ jobs:
             --build ${{ env.BUILD_ARCH }} \
             --dist ${{ matrix.dist }} *.dsc
     - name: Upload binary package artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: binary-${{ matrix.dist }}-${{ matrix.arch }}
         path: |
@@ -96,12 +111,13 @@ jobs:
     env:
       ARCH: amd64
     strategy:
+      fail-fast: false
       matrix:
         image: ${{ fromJSON(vars.SMOKE_TEST_IMAGES) }}
     container: ${{ matrix.image }}
     steps:
     - name: Get binary packages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
     - name: Install packages
       run: |
         apt-get update
@@ -116,6 +132,7 @@ jobs:
         echo ping | redis-cli -p 26379
 
   upload-packages:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
     env:
       DEB_S3_VERSION: "0.11.3"
     runs-on: ubuntu-latest
@@ -128,7 +145,7 @@ jobs:
       env:
         APT_SIGNING_KEY: ${{ secrets.APT_SIGNING_KEY }}
     - name: Get binary packages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/nightly-unstable-package.yaml
+++ b/.github/workflows/nightly-unstable-package.yaml
@@ -1,0 +1,10 @@
+name: Nightly Unstable Build and Package
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # Run at 1:00 AM UTC every day
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  call-unstable-build:
+    uses: redis/redis-debian/.github/workflows/apt.yml@unstable

--- a/README.md
+++ b/README.md
@@ -36,6 +36,5 @@ Redis officially tests the latest version of this distribution against the follo
 
 - Ubuntu 24.04 (Noble Numbat)
 - Ubuntu 22.04 (Jammy Jellyfish)
-- Ubuntu 20.04 (Focal Fossa)
 - Debian 12 (Bookworm)
 - Debian 11 (Bullseye)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-Redis debian packages
-=====================
+This repository holds the `debian/` package configuration and handles automation tasks for creating source packages and pushing them to `ppa:redislabs/redis`.
 
-This repository holds the `debian/` package configuration and handles automation
-tasks for creating source packages and pushing them to `ppa:redislabs/redis`.
+The Debian package is derived from work done by [Chris Lea](https://github.com/chrislea).
 
-The Debian package is derived from work done by [Chris
-Lea](https://github.com/chrislea).
+## Redis Community Edition - Install using Debian Advanced Package Tool (APT)
+
+To install the latest version of Redis Community Edition using the Debian Advanced Package Tool (APT), please use the following command:
+
+-- TODO
+
+## Supported Operating Systems
+
+Redis officially tests the latest version of this distribution against the following OSes:
+
+- Ubuntu 24.04 (Noble Numbat)
+- Ubuntu 22.04 (Jammy Jellyfish)
+- Ubuntu 20.04 (Focal Fossa)
+- Debian 12 (Bookworm)
+- Debian 11 (Bullseye)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,33 @@ This repository holds the `debian/` package configuration and handles automation
 
 The Debian package is derived from work done by [Chris Lea](https://github.com/chrislea).
 
-## Redis Community Edition - Install using Debian Advanced Package Tool (APT)
+## Redis Open Source - Install using Debian Advanced Package Tool (APT)
 
-To install the latest version of Redis Community Edition using the Debian Advanced Package Tool (APT), please use the following command:
+Run the following commands:
+```sh
+sudo apt-get update
+sudo apt-get install lsb-release curl gpg
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+sudo chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+sudo apt-get update
+sudo apt-get install redis
+```
 
--- TODO
+> [!TIP]
+> Redis will not start automatically, nor will it start at boot time. To do this, run the following commands.
+> ```sh
+> sudo systemctl enable redis-server
+> sudo systemctl start redis-server
+> ```
+
+> [!TIP]
+> To install an earlier version, say `7.4.2`, run the following command:
+> ```sh
+> sudo apt-get install redis=6:7.4.2-1rl1~jammy1
+> ```
+>
+> You could view the available versions by running `apt policy redis`.
 
 ## Supported Operating Systems
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Debian Distributions
+
+We support Debian versions that are under [`Debian Security Support / stable versions`](https://wiki.debian.org/Status/Stable) that are official supported by Debian. [Updated support matrix](https://wiki.debian.org/LTS/).
+
+We encourage you to use the latest stable Debian version, and to consider that the 'LTS' versions of Debian are maintained by volunteers - not by the Debian security team.
+
+### Supported Versions
+
+Please refer to our security policy [here](https://github.com/redis/redis/security)
+
+## Reporting a Vulnerability
+
+If you believe you've discovered a serious vulnerability, please contact the
+Redis core team at `redis@redis.io`. We will evaluate your report and if
+necessary issue a fix and an advisory. If the issue was previously undisclosed,
+we'll also mention your name in the credits.
+
+## Responsible Disclosure
+
+In some cases, we may apply a responsible disclosure process to reported or
+otherwise discovered vulnerabilities. We will usually do that for a critical
+vulnerability, and only if we have a good reason to believe information about
+it is not yet public.
+
+This process involves providing an early notification about the vulnerability,
+its impact and mitigations to a short list of vendors under a time-limited
+embargo on public disclosure.
+
+If you believe you should be on the list, please contact us and we will
+consider your request based on the above criteria.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Debian Distributions
 
-We support Debian versions that are under [`Debian Security Support / stable versions`](https://wiki.debian.org/Status/Stable) that are official supported by Debian. [Updated support matrix](https://wiki.debian.org/LTS/).
+We support Debian versions that are under [`Debian Security Support / stable versions`](https://wiki.debian.org/Status/Stable) that are officially supported by Debian. [Updated support matrix](https://wiki.debian.org/LTS/).
 
 We encourage you to use the latest stable Debian version, and to consider that the 'LTS' versions of Debian are maintained by volunteers - not by the Debian security team.
 

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,8 @@ Build-Depends:
  libssl-dev,
  libsystemd-dev,
  pkg-config,
+ llvm,
+ libclang-dev,
  procps <!nocheck>,
  tcl <!nocheck>,
  tcl-tls <!nocheck>

--- a/debian/redis-sentinel.install
+++ b/debian/redis-sentinel.install
@@ -1,2 +1,1 @@
-debian/redis-sentinel.service /lib/systemd/system
 sentinel.conf	/etc/redis

--- a/debian/redis-server.install
+++ b/debian/redis-server.install
@@ -1,2 +1,1 @@
-debian/redis-server.service /lib/systemd/system
 redis.conf	/etc/redis

--- a/release.sh
+++ b/release.sh
@@ -16,7 +16,7 @@ fi
 AUTHOR=$(grep -m 1 '^ --' debian/changelog | sed 's/^ -- \(.*>\)  *.*$/\1/')
 
 sed -i "1i \
-redis (6:$VERSION-1rl1~@RELEASE@1) @RELEASE; urgency=low\n\
+redis (6:$VERSION-1rl1~@RELEASE@1) @RELEASE@; urgency=low\n\
 \n\
   * Redis $VERSION: https://github.com/redis/redis/releases/tag/$VERSION\n\
 \n\

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+if [ $# != 1 ]; then
+    echo "usage: release.sh [version]"
+    exit 1
+fi
+
+set -e
+VERSION="$1"
+
+LATEST_VERSION=$(head -1 debian/changelog | sed 's/^.*([0-9]*:\([0-9\.]*\)-.*$/\1/')
+if [ "$LATEST_VERSION" = "$VERSION" ]; then
+    echo "To re-package the last release, please manually update debian/changelog."
+    exit 1
+fi
+
+AUTHOR=$(grep -m 1 '^ --' debian/changelog | sed 's/^ -- \(.*>\)  *.*$/\1/')
+
+sed -i "1i \
+redis (6:$VERSION-1rl1~@RELEASE@1) @RELEASE; urgency=low\n\
+\n\
+  * Redis $VERSION: https://github.com/redis/redis/releases/tag/$VERSION\n\
+\n\
+ -- $AUTHOR  $(date -R)\n" debian/changelog
+
+git add debian/changelog
+git commit -m "Redis $VERSION"

--- a/setup_sbuild.sh
+++ b/setup_sbuild.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 if [ $# != 2 ]; then
     echo "Please use: setup_build.sh [dist] [arch]"
@@ -13,11 +12,18 @@ else
     disttype="debian"
 fi
 
-# Determine base apt repository URL based on type of distribution.
+if [ "$dist" = "focal" ]; then
+     ubuntu_ports="/ubuntu-ports"
+fi
+# Determine base apt repository URL based on type of distribution and architecture.
 case "$disttype" in
     ubuntu)
-        url=http://archive.ubuntu.com/ubuntu
-        ;;
+        if [ "$arch" = "arm64" ] || [ "$arch" = "armhf" ]; then
+            url=http://ports.ubuntu.com/ubuntu-ports
+        else
+            url=http://archive.ubuntu.com/ubuntu
+        fi
+         ;;
     debian)
         url=http://deb.debian.org/debian
         ;;
@@ -31,12 +37,34 @@ sbuild-createchroot \
     ${dist} `mktemp -d` ${url}
 
 # Ubuntu has the main and ports repositories on different URLs, so we need to
-# properly set up /etc/apt/sources.list to make cross compilation work.
+# properly set up /etc/apt/sources.list to make cross compilation work
+# and enable multi-architecture support inside a chroot environment
 if [ "$disttype" = "ubuntu" ]; then
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture i386
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture armhf
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture arm64
+    # Update /etc/apt/sources.list for cross-compilation (Ubuntu)
     cat <<__END__ | schroot -c source:${dist}-${arch}-sbuild -d / -- tee /etc/apt/sources.list
 deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu ${dist} main universe
 deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu ${dist}-updates main universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com ${dist} main universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com ${dist}-updates main universe
+deb [arch=armhf,arm64] http://ports.ubuntu.com${ubuntu_ports} ${dist} main universe
+deb [arch=armhf,arm64] http://ports.ubuntu.com${ubuntu_ports} ${dist}-updates main universe
 __END__
+
+elif [ "$disttype" = "debian" ]; then
+#   enable multi-architecture support inside a chroot environment
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture i386
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture armhf
+    schroot -c source:${dist}-${arch}-sbuild -d / -- dpkg --add-architecture arm64
+    # Update /etc/apt/sources.list for cross-compilation  (Debian)
+    cat <<__END__ | schroot -c source:${dist}-${arch}-sbuild -d / -- tee /etc/apt/sources.list
+deb [arch=amd64,i386,armhf,arm64] http://deb.debian.org/debian ${dist} main contrib non-free non-free-firmware
+deb [arch=amd64,i386,armhf,arm64] http://deb.debian.org/debian ${dist}-updates main contrib non-free non-free-firmware
+deb [arch=amd64,i386,armhf,arm64] http://deb.debian.org/debian-security ${dist}-security main contrib non-free non-free-firmware
+__END__
+fi
+if [ "$dist" = "focal" ]; then
+    # Install gcc-10 and g++-10 which are required in case of Ubuntu Focal to support Ranges library, introduced in C++20
+    schroot -c source:${dist}-${arch}-sbuild -d / -- bash -c "apt update && apt remove -y gcc-9 g++-9 gcc-9-base && apt upgrade -yqq && apt install -y gcc build-essential gcc-10 g++-10 clang-format clang lcov openssl"
+    schroot -c source:${dist}-${arch}-sbuild -d / -- bash -c "[ -f /usr/bin/gcc-10 ] && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10|| echo 'gcc-10 installation failed'"
 fi


### PR DESCRIPTION
Nightly Unstable Build and Package fails in job "build-binary-package (noble, arm64)" while building RediSearch Rust bindings:

- missing `llvm-config`: clang-sys cannot locate libclang
- missing `libclang.so`: dynamic lookup fails (invalid: [])

This change adds the minimal dependencies to the source package Build-Depends so sbuild installs them inside the chroot:
- `llvm` (provides llvm-config)
- `libclang-dev` (provides libclang.so)

This should allow clang-sys to discover libclang without additional env config. If this still fails due to versioned tools, we can switch to `llvm-18`/`libclang-18-dev` and export `LLVM_CONFIG_PATH=/usr/bin/llvm-config-18` in debian/rules, but keeping it generic is preferable initially.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author