### PR TITLE
debian: add llvm and libclang-dev to Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,8 @@ Build-Depends:
  g++ <!cross>,
  clang <!cross>,
  systemd,
+ llvm,
+ libclang-dev,
  procps <!nocheck>,
  tcl <!nocheck>,
  tcl-tls <!nocheck>


### PR DESCRIPTION
Nightly Unstable Build and Package fails in job "build-binary-package (noble, arm64)" while building RediSearch Rust bindings:

- missing `llvm-config`: clang-sys cannot locate libclang
- missing `libclang.so`: dynamic lookup fails (invalid: [])

This change adds the minimal dependencies to the source package Build-Depends so sbuild installs them inside the chroot:
- `llvm` (provides llvm-config)
- `libclang-dev` (provides libclang.so)

This should allow clang-sys to discover libclang without additional env config. If this still fails due to versioned tools, we can switch to `llvm-18`/`libclang-18-dev` and export `LLVM_CONFIG_PATH=/usr/bin/llvm-config-18` in debian/rules, but keeping it generic is preferable initially.