### PR TITLE
unstable: add llvm and libclang-dev to Build-Depends and CI deps (fix clang-sys)

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
           sudo apt-get update && \
           sudo apt-get install \
-           debhelper dput tcl-tls libsystemd-dev pkgconf cmake clang libssl-dev
+           debhelper dput tcl-tls libsystemd-dev pkgconf cmake clang libssl-dev llvm libclang-dev
     - name: Determine version
       run: |
           VERSION="unstable"


### PR DESCRIPTION
Fix nightly/CI failures due to clang-sys not finding llvm-config/libclang.

Changes:
- .github/workflows/apt.yml: install `llvm` and `libclang-dev` in build-source-package job so `dpkg-checkbuilddeps` passes on the runner
