### PR TITLE
ci(apt): checkout current ref and add safe matrix defaults (stabilize PR builds)

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: ${{ fromJSON(vars.BUILD_DISTS) }}
-        arch: ${{ fromJSON(vars.BUILD_ARCHS) }}
-        exclude: ${{ fromJSON(vars.BUILD_EXCLUDE) }}
+        dist: ${{ fromJSON(inputs.dists || vars.BUILD_DISTS || '["bookworm","jammy","noble"]') }}
+        arch: ${{ fromJSON(inputs.archs || vars.BUILD_ARCHS || '["amd64","arm64"]') }}
+        exclude: ${{ fromJSON(inputs.exclude || vars.BUILD_EXCLUDE || '[]') }}
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: unstable
+        ref: ${{ inputs.ref || github.ref }}
     - name: Install dependencies
       run: |
           sudo apt-get update && \
@@ -72,14 +72,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: ${{ fromJSON(vars.BUILD_DISTS) }}
-        arch: ${{ fromJSON(vars.BUILD_ARCHS) }}
-        exclude: ${{ fromJSON(vars.BUILD_EXCLUDE) }}
+        dist: ${{ fromJSON(inputs.dists || vars.BUILD_DISTS || '["bookworm","jammy","noble"]') }}
+        arch: ${{ fromJSON(inputs.archs || vars.BUILD_ARCHS || '["amd64","arm64"]') }}
+        exclude: ${{ fromJSON(inputs.exclude || vars.BUILD_EXCLUDE || '[]') }}
     needs: build-source-package
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: unstable
+        ref: ${{ inputs.ref || github.ref }}
     - name: Determine build architecture
       run: |
           case ${{ matrix.arch }} in
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ fromJSON(vars.SMOKE_TEST_IMAGES) }}
+        image: ${{ fromJSON(vars.SMOKE_TEST_IMAGES || '["ubuntu:22.04"]') }}
         arch: [amd64, arm64]
     container: ${{ matrix.image }}
     steps:


### PR DESCRIPTION
Problem: PR builds used apt.yml from unstable and checked out unstable ref, so they didn't include PR changes (e.g., debian/rules IGNORE_MISSING_DEPS=1) and failed on RediSearch `uv` deps gate. Also, fromJSON(...) failed when repo vars were not set in fork/PR context.

Fix:
- Use the current ref by default in checkout: `ref: ${{ inputs.ref || github.ref }}`
- Provide safe defaults for matrices when vars are missing, and accept inputs for reusable calls.

Nightly remains unaffected because it has repo vars and uses the workflow via the unstable ref.

This is a temporary stabilization so we can verify PR builds compile; can be revisited/cleaned up after verification.

---
PR opened by Augment Code on behalf of @mike-golant

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author