### PR TITLE
Revert trigger back to workflow call

### DIFF
--- a/.github/workflows/nightly-unstable-package.yaml
+++ b/.github/workflows/nightly-unstable-package.yaml
@@ -6,13 +6,5 @@ on:
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
-  trigger-unstable-build:
-    # avoid running in forks
-    if: github.repository == 'redis/redis-debian'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger apt.yml workflow on unstable branch
-        run: |
-          gh workflow run apt.yml --ref unstable
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  call-unstable-build:
+    uses: redis/redis-debian/.github/workflows/apt.yml@unstable


### PR DESCRIPTION
We can't use trigger since ce-testing expects nighlty workflow to be the one which runs actual build and not just trigger it