### PR TITLE
Fix unstable checkout

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -36,6 +36,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: >-
+            ${{ (github.ref_name == 'unstable'
+            || github.event_name == 'workflow_dispatch'
+            || github.event_name == 'workflow_call'
+            || github.event_name == 'schedule')
+            && 'unstable'
+            || ''
+            }}
 
       - name: Parse vars
         id: parse


### PR DESCRIPTION
This should fix nightly build error. The reason is that `apt.yml` is started in `master` and we have to switch branches manually whenever we use any other actions or reusable workflows.