### PR TITLE
Fix checkout in unstable branch

### DIFF
--- a/.github/actions/parse-env-file/action.yml
+++ b/.github/actions/parse-env-file/action.yml
@@ -24,9 +24,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
     - name: Parse release handle
       id: parse
       shell: bash

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Parse vars
+        id: parse
+        uses: ./.github/actions/parse-env-file
+
       - name: Validate Redis Release Archive
         uses: redis-developer/redis-oss-release-automation/.github/actions/validate-redis-release-archive@main
         with:
@@ -44,16 +48,6 @@ jobs:
           release_tag: ${{ github.event.inputs.release_tag }}
           release_version_branch: ${{ steps.ensure-branch.outputs.release_version_branch }}
           release_type: ${{ github.event.inputs.release_type }}
-
-  populate-env-vars:
-    runs-on: ["ubuntu-latest"]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Parse vars
-        id: parse
-        uses: ./.github/actions/parse-env-file
     outputs:
       BUILD_ARCHS: ${{ steps.parse.outputs.BUILD_ARCHS }}
       BUILD_DISTS: ${{ steps.parse.outputs.BUILD_DISTS }}
@@ -63,13 +57,12 @@ jobs:
   build-n-test:
     needs: 
       - prepare-release
-      - populate-env-vars
     uses: ./.github/workflows/build-n-test-all-distros.yml
     with:
-      BUILD_DISTS: ${{ needs.populate-env-vars.outputs.BUILD_DISTS }}
-      BUILD_ARCHS: ${{ needs.populate-env-vars.outputs.BUILD_ARCHS }}
-      BUILD_EXCLUDE: ${{ needs.populate-env-vars.outputs.BUILD_EXCLUDE }}
-      SMOKE_TEST_IMAGES: ${{ needs.populate-env-vars.outputs.SMOKE_TEST_IMAGES }}
+      BUILD_DISTS: ${{ needs.prepare-release.outputs.BUILD_DISTS }}
+      BUILD_ARCHS: ${{ needs.prepare-release.outputs.BUILD_ARCHS }}
+      BUILD_EXCLUDE: ${{ needs.prepare-release.outputs.BUILD_EXCLUDE }}
+      SMOKE_TEST_IMAGES: ${{ needs.prepare-release.outputs.SMOKE_TEST_IMAGES }}
       release_tag: ${{ inputs.release_tag }}
 
   create-release-handle:


### PR DESCRIPTION
parse-env-file used to have its own checkout which conflicts with calling workflow checkout

Moved parse-env-file action usage to prepare-release job for release_build_and_test.yml workflow it would allow to use the same checkout and the same runner

And removed internal checkout action from parse-env-files action. In apt.yml there was already checkout action in front of parse