### PR TITLE
Fix to only force CC for cross-compilation; exercise unstable in PRs

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -64,11 +64,12 @@ jobs:
       BUILD_EXCLUDE: ${{ needs.populate-env-vars.outputs.BUILD_EXCLUDE }}
       SMOKE_TEST_IMAGES: ${{ needs.populate-env-vars.outputs.SMOKE_TEST_IMAGES }}
       # Determine whether we should use special "unstable" release_tag. Assume
-      # that for unstable branch and for any external call, dispatch or schedule
-      # we are building unstable release. In other cases it's a regular PR/push
-      # build without using specific release_tag.
+      # that for unstable branch (push or PR), and for any external call,
+      # dispatch or schedule we are building unstable release. In other cases
+      # it's a regular PR/push build without using specific release_tag.
       release_tag: >-
         ${{ (github.ref_name == 'unstable'
+        || github.base_ref == 'unstable'
         || github.event_name == 'workflow_dispatch'
         || github.event_name == 'workflow_call'
         || github.event_name == 'schedule')

--- a/.github/workflows/build-n-test-all-distros.yml
+++ b/.github/workflows/build-n-test-all-distros.yml
@@ -36,7 +36,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
+        # On PRs keep the PR head even when release_tag=unstable, so the PR's
+        # debian/ packaging is what gets tested; the redis source tarball is
+        # still fetched from redis/redis@unstable inside build-source-package.
+        ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - name: Ensure Release Branch
       if: inputs.release_tag != '' && inputs.release_tag != 'unstable'
       id: ensure-branch
@@ -63,7 +66,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
+        # See build-source-package above.
+        ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - name: Ensure Release Branch
       if: inputs.release_tag != '' && inputs.release_tag != 'unstable'
       id: ensure-branch
@@ -107,7 +111,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
+        # See build-source-package above.
+        ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - uses: ./.github/actions/run-smoke-tests
       with:
         image: ${{ matrix.image }}

--- a/debian/rules
+++ b/debian/rules
@@ -3,11 +3,15 @@
 include /usr/share/dpkg/architecture.mk
 include /usr/share/dpkg/buildflags.mk
 
-ifneq ($(DEB_HOST_GNU_TYPE),)
+ifneq ($(DEB_HOST_GNU_TYPE),$(DEB_BUILD_GNU_TYPE))
 CC = $(DEB_HOST_GNU_TYPE)-gcc
+export CC
+else
+# sbuild leaks CC=...-gcc on native builds; drop it so RediSearch picks clang-21.
+unexport CC
 endif
 
-export CC CFLAGS CPPFLAGS LDFLAGS
+export CFLAGS CPPFLAGS LDFLAGS
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all,-format
 export DEB_LDFLAGS_MAINT_APPEND = -ldl -latomic
 export REDIS_CFLAGS='-Wno-error=uninitialized'
@@ -71,13 +75,11 @@ override_dh_auto_install:
 
 override_dh_auto_build:
 ifeq ($(BUILD_WITH_MODULES),yes)
-ifeq ($(DEB_HOST_GNU_TYPE),$(DEB_BUILD_GNU_TYPE))
-	# Native: drop CC so RediSearch picks up clang-21 (matches rustc 1.94's LLVM)
-	# for its LTO step; Redis core and other modules fall back to default cc.
-	env -u CC dh_auto_build --parallel -- V=1 BUILD_TLS=yes
-else
-	# Cross: clang-21 is gated by <!cross>, so disable LTO.
+ifneq ($(DEB_HOST_GNU_TYPE),$(DEB_BUILD_GNU_TYPE))
+	# Cross + modules: clang-21 is gated by <!cross>, so disable LTO.
 	dh_auto_build --parallel -- V=1 BUILD_TLS=yes LTO=0
+else
+	dh_auto_build --parallel -- V=1 BUILD_TLS=yes
 endif
 else
 	dh_auto_build --parallel -- V=1 BUILD_TLS=yes


### PR DESCRIPTION
Two fixes to unblock the unstable build matrix after upstream Redis enabled `LTO ?= 1` in RediSearch.
### debian/rules
`sbuild`/`dpkg-buildpackage` leak `CC=$(DEB_HOST_GNU_TYPE)-gcc` into the env even on native runs, and RediSearch's build script aborts with `"LTO requires clang as the C compiler"`. `dh_auto_install` re-invokes that script (during the modules install target), so fixing `dh_auto_build` alone wasn't enough.
- Only force `CC` for actual cross-compilation (`host != build`).
- For native builds, `unexport CC` so make doesn't forward the leaked value to any recipe shell, letting RediSearch auto-detect `clang-21` from `PATH`.
- Drop the `LTO=0` branch for apparent-native + modules (now the default path); keep `LTO=0` only on real cross + modules where `clang-21` is gated by `<!cross>`.
### CI
The bug slipped past PR CI because PRs targeting `unstable` were running against the Redis tag pinned in `debian/changelog` (e.g. 8.4.0), not `redis/redis@unstable`.
- `apt.yml`: also set `release_tag='unstable'` when `github.base_ref == 'unstable'`, so PRs against unstable now fetch `redis/redis@unstable` and actually exercise the LTO path.
- `build-n-test-all-distros.yml`: on `pull_request` runs, don't override the checkout to the live `unstable` branch — keep the PR's proposed `debian/` packaging while still using the unstable Redis source.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI workflow logic and Debian packaging build flags; mistakes could cause builds to test the wrong branch or fail due to compiler/LTO selection, but scope is limited to packaging/CI.
> 
> **Overview**
> Adjusts the “unstable” build semantics in GitHub Actions so PRs targeting `unstable` are treated as `release_tag=unstable`, while reusable workflow jobs **do not** check out the `unstable` branch on pull requests (they keep the PR head so packaging changes are actually tested).
> 
> Updates `debian/rules` to only set/export `CC=$(DEB_HOST_GNU_TYPE)-gcc` for true cross-compiles (`DEB_HOST_GNU_TYPE != DEB_BUILD_GNU_TYPE`), explicitly unexports `CC` for native builds, and simplifies the modules build path by removing the `env -u CC` wrapper while still disabling LTO (`LTO=0`) for cross+modules builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cbce44c108acf60a95f3a48ef8a8307d29aa2e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->