### PR TITLE
Build PRs targeting unstable against redis/redis@unstable

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -64,11 +64,12 @@ jobs:
       BUILD_EXCLUDE: ${{ needs.populate-env-vars.outputs.BUILD_EXCLUDE }}
       SMOKE_TEST_IMAGES: ${{ needs.populate-env-vars.outputs.SMOKE_TEST_IMAGES }}
       # Determine whether we should use special "unstable" release_tag. Assume
-      # that for unstable branch and for any external call, dispatch or schedule
-      # we are building unstable release. In other cases it's a regular PR/push
-      # build without using specific release_tag.
+      # that for unstable branch (push or PR), and for any external call,
+      # dispatch or schedule we are building unstable release. In other cases
+      # it's a regular PR/push build without using specific release_tag.
       release_tag: >-
         ${{ (github.ref_name == 'unstable'
+        || github.base_ref == 'unstable'
         || github.event_name == 'workflow_dispatch'
         || github.event_name == 'workflow_call'
         || github.event_name == 'schedule')

--- a/.github/workflows/build-n-test-all-distros.yml
+++ b/.github/workflows/build-n-test-all-distros.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
+        ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - name: Ensure Release Branch
       if: inputs.release_tag != '' && inputs.release_tag != 'unstable'
       id: ensure-branch
@@ -63,7 +63,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
+        ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - name: Ensure Release Branch
       if: inputs.release_tag != '' && inputs.release_tag != 'unstable'
       id: ensure-branch
@@ -107,7 +107,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
+        ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - uses: ./.github/actions/run-smoke-tests
       with:
         image: ${{ matrix.image }}


### PR DESCRIPTION
PRs against the unstable branch were running their CI against the Redis tag pinned in debian/changelog (e.g. 8.4.0).

apt.yml: also set release_tag='unstable' when github.base_ref == 'unstable' (i.e. PR target branch is unstable). This makes build-source-package fetch redis/redis@unstable instead of the changelog-pinned tag.

build-n-test-all-distros.yml: don't switch the redis-debian checkout to the live 'unstable' branch in pull_request runs - we still want to test the PR's proposed code, just with redis/redis@unstable as the source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI branch/ref selection logic for unstable builds, which could alter what code is built/tested in PRs vs scheduled runs. Risk is limited to workflow behavior but could cause incorrect artifacts or missed regressions if the conditions are wrong.
> 
> **Overview**
> PRs **targeting** `unstable` now set `release_tag: unstable` in `apt.yml` (via `github.base_ref`), so they build against `redis/redis@unstable` rather than the version pinned in `debian/changelog`.
> 
> In `build-n-test-all-distros.yml`, the `actions/checkout` ref is no longer forced to `unstable` during `pull_request` runs, ensuring PR CI tests the proposed changes while still using the unstable release tag for downstream build steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2ccb2e9b0f7f1a8b770e35e133ad5cc11e1543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->