### PR TITLE
Update the list of supported OS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ This will start `redis-server` with `/etc/redis/redis.conf`.
 
 Redis officially tests the latest version of this distribution against the following OSes:
 
+- Ubuntu 26.04 (Resolute Raccoon)
 - Ubuntu 24.04 (Noble Numbat)
 - Ubuntu 22.04 (Jammy Jellyfish)
+- Debian 13 (Trixie)
 - Debian 12 (Bookworm)
 - Debian 11 (Bullseye)


### PR DESCRIPTION
Added Ubuntu 26.04 and Debian Trixie

For #79 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on builds, packages, or runtime behavior.
> 
> **Overview**
> The **Supported Operating Systems** section in `README.md` now lists **Ubuntu 26.04 (Resolute Raccoon)** and **Debian 13 (Trixie)** alongside the existing Ubuntu and Debian entries. No packaging, build, or runtime code is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb3772ace0e25641844eedb3726b58ab40ef5a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->