### PR TITLE
RED-198334 Bump GH Actions off Node 20

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: |
           sudo apt-get update && \
@@ -36,7 +36,7 @@ jobs:
           sed -i "s/@RELEASE@/${{ matrix.dist }}/g" redis-${VERSION}/debian/changelog
           ( cd redis-${VERSION} && dpkg-buildpackage -S )
     - name: Upload source package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: source-${{ matrix.dist }}
         path: |
@@ -54,7 +54,7 @@ jobs:
         exclude: ${{ fromJSON(vars.BUILD_EXCLUDE) }}
     needs: build-source-package
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Determine build architecture
       run: |
           case ${{ matrix.arch }} in
@@ -88,7 +88,7 @@ jobs:
     - name: Prepare sbuild environment
       run: sudo ./setup_sbuild.sh ${{ matrix.dist }} ${{ env.BUILD_ARCH }}
     - name: Get source package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: source-${{ matrix.dist }}
     - name: Build binary package
@@ -99,7 +99,7 @@ jobs:
             --build ${{ env.BUILD_ARCH }} \
             --dist ${{ matrix.dist }} *.dsc
     - name: Upload binary package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: binary-${{ matrix.dist }}-${{ matrix.arch }}
         path: |
@@ -117,7 +117,7 @@ jobs:
     container: ${{ matrix.image }}
     steps:
     - name: Get binary packages
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
     - name: Install packages
       run: |
         apt-get update
@@ -145,7 +145,7 @@ jobs:
       env:
         APT_SIGNING_KEY: ${{ secrets.APT_SIGNING_KEY }}
     - name: Get binary packages
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create source package and upload to Lauchpad
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: |
           sudo apt-get update && sudo apt-get install debhelper dput tcl-tls libsystemd-dev pkg-config


### PR DESCRIPTION
## Summary
RED-198334. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline.

- Bump `actions/checkout` to `@v6` (3 sites: `apt.yml` x2, `ppa.yml` x1)
- Bump `actions/upload-artifact@v4` -> `@v7` (2 sites in `apt.yml`)
- Bump `actions/download-artifact@v4` -> `@v7` (3 sites in `apt.yml`)

## Test plan
- [ ] `apt.yml` builds source + binary package matrix on this PR
- [ ] `ppa.yml` is only triggered on push to `ppa` branch; verify on next ppa push
- [ ] No artifact name collisions after upload/download-artifact v4 -> v7 bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency version bumps with no changes to build logic, secrets handling, or release steps beyond newer action runtimes.
> 
> **Overview**
> Updates Debian packaging workflows ahead of GitHub’s Node 20 deprecation by moving shared Actions to newer major versions.
> 
> In **`apt.yml`**, **`actions/checkout`** goes from **v4 → v6** on the source and binary build jobs; **`actions/upload-artifact`** and **`actions/download-artifact`** go from **v4 → v7** across source upload, binary download/upload, smoke tests, and final package upload. In **`ppa.yml`**, **`actions/checkout`** is bumped from **v2 → v6**. Job steps, matrix, and artifact naming are unchanged—only action pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ad6f20a4c68b2d2dbdaa771763abfcb9bb6bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->