### PR TITLE
RED-198334 Bump GH Actions off Node 20 (unstable)

### DIFF
--- a/.github/actions/build-binary-package/action.yml
+++ b/.github/actions/build-binary-package/action.yml
@@ -1,4 +1,6 @@
 name: "Build binary package"
+description: "Build binary .deb package for a given distribution and architecture"
+
 inputs:
   run_id:
     description: "Run ID to download artifacts from"
@@ -44,7 +46,7 @@ runs:
       shell: bash
       run: sudo ./setup_sbuild.sh ${{ inputs.dist }} ${{ env.BUILD_ARCH }}
     - name: Get source package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: source-${{ inputs.dist }}
         run-id: ${{ inputs.run_id }}
@@ -61,7 +63,7 @@ runs:
             --chroot-setup-commands="apt-get update && apt-get install -y build-essential" \
             *.dsc
     - name: Upload binary package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: binary-${{ inputs.dist }}-${{ inputs.arch }}
         path: |

--- a/.github/actions/build-source-package/action.yml
+++ b/.github/actions/build-source-package/action.yml
@@ -1,4 +1,5 @@
 name: "Build source package"
+description: "Build a Debian source package (.dsc + tarball) for a given distribution"
 
 inputs:
   dist:
@@ -66,7 +67,7 @@ runs:
       sed -i "s/@RELEASE@/${{ inputs.dist }}/g" redis-${VERSION}/debian/changelog
       ( cd redis-${VERSION} && dpkg-buildpackage -S )
   - name: Upload source package artifact
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@v7
     with:
       name: source-${{ inputs.dist }}
       path: |

--- a/.github/actions/bump-debian-changelog/action.yml
+++ b/.github/actions/bump-debian-changelog/action.yml
@@ -1,3 +1,6 @@
+name: "Bump debian changelog"
+description: "Bump debian/changelog with the release tag and create a verified commit"
+
 inputs:
   release_tag:
     description: 'Release tag to build'
@@ -19,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout common functions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis-developer/redis-oss-release-automation
         ref: main
@@ -33,7 +36,7 @@ runs:
 
     - name: Create verified commit
       if: steps.bump-version.outputs.changed_files != ''
-      uses: iarekylew00t/verified-bot-commit@v1
+      uses: iarekylew00t/verified-bot-commit@v2
       with:
         message: ${{ inputs.release_tag }}
         files: ${{ steps.bump-version.outputs.changed_files }}

--- a/.github/actions/run-smoke-tests/action.yml
+++ b/.github/actions/run-smoke-tests/action.yml
@@ -1,4 +1,6 @@
 name: "Run smoke tests"
+description: "Run smoke tests against the built Debian packages"
+
 inputs:
   run_id:
     description: "Run ID to download artifacts from"
@@ -21,7 +23,7 @@ runs:
       DIST=$(echo "$IMAGE" | cut -d':' -f2)
       echo "distribution=$DIST" >> $GITHUB_OUTPUT
   - name: Get binary packages
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@v7
     with:
       name: binary-${{ steps.extract_dist.outputs.distribution }}-${{ inputs.arch }}
   - name: Install packages

--- a/.github/actions/upload-packages/action.yml
+++ b/.github/actions/upload-packages/action.yml
@@ -1,4 +1,5 @@
 name: "Upload deb to S3"
+description: "Sign and upload Debian packages to S3"
 
 inputs:
   run_id:
@@ -72,7 +73,7 @@ runs:
   # For internal release we have an IAM role that we need to assume
   - name: Configure aws credentials for internal release
     if: ${{ inputs.release_type == 'internal' }}
-    uses: aws-actions/configure-aws-credentials@v4.3.1
+    uses: aws-actions/configure-aws-credentials@v6
     with:
       role-to-assume: ${{ inputs.APT_S3_IAM_ARN }}
       aws-region: us-east-1
@@ -94,7 +95,7 @@ runs:
       APT_SIGNING_KEY: ${{ inputs.APT_SIGNING_KEY }}
 
   - name: Get binary packages
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@v7
     with:
       run-id: ${{ inputs.run_id }}
       github-token: ${{ inputs.gh_token }}

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: >-
             ${{ (github.ref_name == 'unstable'

--- a/.github/workflows/build-n-test-all-distros.yml
+++ b/.github/workflows/build-n-test-all-distros.yml
@@ -34,7 +34,7 @@ jobs:
         dist: ${{ fromJSON(inputs.BUILD_DISTS) }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # On PRs keep the PR head even when release_tag=unstable, so the PR's
         # debian/ packaging is what gets tested; the redis source tarball is
@@ -64,7 +64,7 @@ jobs:
     needs: build-source-package
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # See build-source-package above.
         ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
@@ -109,7 +109,7 @@ jobs:
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # See build-source-package above.
         ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Parse vars
         id: parse
@@ -82,7 +82,7 @@ jobs:
           RELEASE_HANDLE
 
       - name: Upload release handle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_handle
           path: result.json

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate inputs
         id: validate-inputs
@@ -112,7 +112,7 @@ jobs:
           RESULT
 
       - name: Upload publish result artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_info
           path: result.json


### PR DESCRIPTION
## Summary
RED-198334 on `unstable`. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline. Companion PR on `master`: [#81](https://github.com/redis/redis-debian/pull/81). The `unstable` branch has substantially more workflow surface than `master`, so this is a separate PR rather than a CP.

- Bump `actions/checkout@v4` -> `@v6` (7 sites), `actions/upload-artifact@v4` -> `@v7` (5 sites), `actions/download-artifact@v4` -> `@v7` (3 sites)
- Bump `aws-actions/configure-aws-credentials@v4.3.1` -> `@v6` in `upload-packages` and `iarekylew00t/verified-bot-commit@v1` -> `@v2` in `bump-debian-changelog`
- Add missing top-level `description:` field to 5 composite actions (`build-binary-package`, `build-source-package`, `bump-debian-changelog` (also missing `name:`), `run-smoke-tests`, `upload-packages`). Required by the GitHub `action.yml` schema; actionlint / reviewdog will flag these when the files are touched (same pattern as the RED-190667 release-8.0.2 fix that added missing descriptions to `setup_python` / `setup_go`)

`ruby/setup-ruby@v1` (rolling v1 on Node 24) is left as-is. `slack-notification/action.yml` is also missing `name:`/`description:` but is not touched in this PR - pre-existing tech debt.

## Test plan
- [ ] `apt.yml` build matrix runs cleanly on `unstable` PR
- [ ] `build-n-test-all-distros.yml` builds + smoke-tests all distros with bumped actions
- [ ] `release_build_and_test.yml` workflow_dispatch run produces verified bot commit via `bump-debian-changelog` with `iarekylew00t/verified-bot-commit@v2`
- [ ] `release_publish.yml` workflow_dispatch uploads packages cleanly via `configure-aws-credentials@v6`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release publish (AWS credential assumption) and verified bot commits, but changes are dependency version bumps with no application code changes; validate via full build/smoke and a release workflow_dispatch.
> 
> **Overview**
> Bumps Debian CI/release GitHub Actions off **Node 20** ahead of GitHub’s deprecation deadline, without changing build or publish logic.
> 
> **Action version bumps** across composite actions and workflows: `actions/checkout` **v4 → v6**, `actions/upload-artifact` **v4 → v7**, `actions/download-artifact` **v4 → v7**, `aws-actions/configure-aws-credentials` **v4.3.1 → v6** (internal S3 upload), and `iarekylew00t/verified-bot-commit` **v1 → v2** (changelog bump commits). Touches APT build/test (`apt.yml`, `build-n-test-all-distros.yml`) and release flows (`release_build_and_test.yml`, `release_publish.yml`).
> 
> **Composite action metadata**: adds top-level `description:` (and `name:` where missing) on five local actions so `action.yml` matches the schema for actionlint/reviewdog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7cd605b52d4d0b1b02a0d1a69d226d7cf2bc933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->