### PR TITLE
RED-198334 Bump GH Actions off Node 20 (release/7.4)

### DIFF
--- a/.github/actions/build-binary-package/action.yml
+++ b/.github/actions/build-binary-package/action.yml
@@ -1,4 +1,6 @@
 name: "Build binary package"
+description: "Build binary .deb package for a given distribution and architecture"
+
 inputs:
   run_id:
     description: "Run ID to download artifacts from"
@@ -43,7 +45,7 @@ runs:
       shell: bash
       run: sudo ./setup_sbuild.sh ${{ inputs.dist }} ${{ env.BUILD_ARCH }}
     - name: Get source package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: source-${{ inputs.dist }}
         run-id: ${{ inputs.run_id }}
@@ -57,7 +59,7 @@ runs:
             --dist ${{ inputs.dist }} \
             *.dsc
     - name: Upload binary package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: binary-${{ inputs.dist }}-${{ inputs.arch }}
         path: |

--- a/.github/actions/build-source-package/action.yml
+++ b/.github/actions/build-source-package/action.yml
@@ -1,4 +1,5 @@
 name: "Build source package"
+description: "Build a Debian source package (.dsc + tarball) for a given distribution"
 
 inputs:
   dist:
@@ -43,7 +44,7 @@ runs:
       sed -i "s/@RELEASE@/${{ inputs.dist }}/g" redis-${VERSION}/debian/changelog
       ( cd redis-${VERSION} && dpkg-buildpackage -S )
   - name: Upload source package artifact
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@v7
     with:
       name: source-${{ inputs.dist }}
       path: |

--- a/.github/actions/bump-debian-changelog/action.yml
+++ b/.github/actions/bump-debian-changelog/action.yml
@@ -1,3 +1,6 @@
+name: "Bump debian changelog"
+description: "Bump debian/changelog with the release tag and create a verified commit"
+
 inputs:
   release_tag:
     description: 'Release tag to build'
@@ -19,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout common functions
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: redis-developer/redis-oss-release-automation
         ref: main
@@ -33,7 +36,7 @@ runs:
 
     - name: Create verified commit
       if: steps.bump-version.outputs.changed_files != ''
-      uses: iarekylew00t/verified-bot-commit@v1
+      uses: iarekylew00t/verified-bot-commit@v2
       with:
         message: ${{ inputs.release_tag }}
         files: ${{ steps.bump-version.outputs.changed_files }}

--- a/.github/actions/run-smoke-tests/action.yml
+++ b/.github/actions/run-smoke-tests/action.yml
@@ -1,4 +1,6 @@
 name: "Run smoke tests"
+description: "Run smoke tests against the built Debian packages"
+
 inputs:
   run_id:
     description: "Run ID to download artifacts from"
@@ -21,7 +23,7 @@ runs:
       DIST=$(echo "$IMAGE" | cut -d':' -f2)
       echo "distribution=$DIST" >> $GITHUB_OUTPUT
   - name: Get binary packages
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@v7
     with:
       name: binary-${{ steps.extract_dist.outputs.distribution }}-${{ inputs.arch }}
   - name: Install packages

--- a/.github/actions/upload-packages/action.yml
+++ b/.github/actions/upload-packages/action.yml
@@ -1,4 +1,5 @@
 name: "Upload deb to S3"
+description: "Sign and upload Debian packages to S3"
 
 inputs:
   run_id:
@@ -72,7 +73,7 @@ runs:
   # For internal release we have an IAM role that we need to assume
   - name: Configure aws credentials for internal release
     if: ${{ inputs.release_type == 'internal' }}
-    uses: aws-actions/configure-aws-credentials@v4.3.1
+    uses: aws-actions/configure-aws-credentials@v6
     with:
       role-to-assume: ${{ inputs.APT_S3_IAM_ARN }}
       aws-region: us-east-1
@@ -94,7 +95,7 @@ runs:
       APT_SIGNING_KEY: ${{ inputs.APT_SIGNING_KEY }}
 
   - name: Get binary packages
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@v7
     with:
       run-id: ${{ inputs.run_id }}
       github-token: ${{ inputs.gh_token }}

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Parse vars
         id: parse

--- a/.github/workflows/build-n-test-all-distros.yml
+++ b/.github/workflows/build-n-test-all-distros.yml
@@ -34,7 +34,7 @@ jobs:
         dist: ${{ fromJSON(inputs.BUILD_DISTS) }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - name: Ensure Release Branch
@@ -61,7 +61,7 @@ jobs:
     needs: build-source-package
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - name: Ensure Release Branch
@@ -105,7 +105,7 @@ jobs:
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
     - uses: ./.github/actions/run-smoke-tests

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate Redis Release Archive
         uses: redis-developer/redis-oss-release-automation/.github/actions/validate-redis-release-archive@main
@@ -89,7 +89,7 @@ jobs:
           RELEASE_HANDLE
 
       - name: Upload release handle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_handle
           path: result.json

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate inputs
         id: validate-inputs
@@ -112,7 +112,7 @@ jobs:
           RESULT
 
       - name: Upload publish result artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_info
           path: result.json


### PR DESCRIPTION
## Summary
Cherry-pick of [#82](https://github.com/redis/redis-debian/pull/82) onto `release/7.4`. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline.

- Bump `actions/checkout@v4` -> `@v6` (7 sites), `actions/upload-artifact@v4` -> `@v7` (5 sites), `actions/download-artifact@v4` -> `@v7` (3 sites)
- Bump `aws-actions/configure-aws-credentials@v4.3.1` -> `@v6` and `iarekylew00t/verified-bot-commit@v1` -> `@v2`
- Add missing top-level `description:` field to 5 composite actions (per the GitHub `action.yml` schema)
- Resolved `apt.yml` conflict: applied only the version bump, dropped the `with: ref:` block (structural, absent on this branch)

## Test plan
- [ ] `apt.yml` build matrix runs cleanly on PR
- [ ] `build-n-test-all-distros.yml` builds + smoke-tests all distros with bumped actions
- [ ] `release_publish.yml` workflow_dispatch uploads packages cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency version bumps with no application or packaging logic changes; main risk is workflow compatibility with newer action major versions.
> 
> **Overview**
> Cherry-pick onto `release/7.4` to move Debian CI off **Node 20** GitHub Actions before the June 2026 deprecation deadline.
> 
> **Action version bumps** across composite actions and workflows: `actions/checkout@v4` → `@v6`, `actions/upload-artifact@v4` → `@v7`, `actions/download-artifact@v4` → `@v7`, `aws-actions/configure-aws-credentials@v4.3.1` → `@v6`, and `iarekylew00t/verified-bot-commit@v1` → `@v2`. These touch build/source packaging, smoke tests, S3 upload, and release build/publish flows.
> 
> Five composite `action.yml` files gain a top-level **`description:`** field for schema compliance. **`apt.yml`** only gets the checkout bump (no extra `with: ref:` changes on this branch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e11a13e72e47d567414cf5212cca286d69242b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->