### PR TITLE
Handle both ways to build modules

### DIFF
--- a/.github/actions/build-source-package/action.yml
+++ b/.github/actions/build-source-package/action.yml
@@ -32,11 +32,22 @@ runs:
         FULL_URL="https://github.com/redis/redis/releases/download/${VERSION}/redis-full.tar.gz"
         TAG_URL="https://github.com/redis/redis/archive/refs/tags/${VERSION}.tar.gz"
 
-        if curl --fail --silent --show-error --location --head "$FULL_URL" --output /dev/null; then
-          URL="$FULL_URL"
-        else
-          URL="$TAG_URL"
+        if ! HTTP_CODE=$(curl --silent --show-error --location --head --output /dev/null --write-out '%{http_code}' "$FULL_URL"); then
+          echo "Failed to check $FULL_URL" >&2
+          exit 1
         fi
+        case "$HTTP_CODE" in
+          2*)
+            URL="$FULL_URL"
+            ;;
+          404)
+            URL="$TAG_URL"
+            ;;
+          *)
+            echo "Unexpected HTTP status while checking $FULL_URL: $HTTP_CODE" >&2
+            exit 1
+            ;;
+        esac
       fi
       echo "VERSION=${VERSION}" >> $GITHUB_ENV
       echo "Determined version $VERSION"

--- a/.github/actions/build-source-package/action.yml
+++ b/.github/actions/build-source-package/action.yml
@@ -29,7 +29,14 @@ runs:
         # Version format:
         # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
         VERSION=$(head -1 debian/changelog | awk '{print $2}' | sed 's/(\([0-9]\+:\)\?\(.*\)-[^-]\+)$/\2/g')
-        URL="https://github.com/redis/redis/releases/download/${VERSION}/redis-full.tar.gz"
+        FULL_URL="https://github.com/redis/redis/releases/download/${VERSION}/redis-full.tar.gz"
+        TAG_URL="https://github.com/redis/redis/archive/refs/tags/${VERSION}.tar.gz"
+
+        if curl --fail --silent --show-error --location --head "$FULL_URL" --output /dev/null; then
+          URL="$FULL_URL"
+        else
+          URL="$TAG_URL"
+        fi
       fi
       echo "VERSION=${VERSION}" >> $GITHUB_ENV
       echo "Determined version $VERSION"
@@ -38,7 +45,7 @@ runs:
   - name: Get source tarball
     shell: bash
     run: |
-      curl --silent -L ${{ steps.determine-version.outputs.URL }} -o redis_${VERSION}.orig.tar.gz
+      curl --fail --silent --show-error --location "${{ steps.determine-version.outputs.URL }}" -o redis_${VERSION}.orig.tar.gz
   - name: Build source package
     shell: bash
     run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only packaging logic with no runtime or security impact; main risk is a wrong fallback URL breaking distro builds for some tags.
> 
> **Overview**
> **Release source packaging** no longer assumes every tagged version publishes `redis-full.tar.gz` on GitHub Releases.
> 
> For non-`unstable` builds, **Determine version** now HEAD-checks the release asset URL. A **2xx** response keeps using `redis-full.tar.gz`; **404** switches to the tag archive (`refs/tags/${VERSION}.tar.gz`). Other HTTP codes fail the step with a clear error. The **Get source tarball** step uses `curl --fail` and quotes the URL so failed downloads stop the job instead of silently producing a bad tarball.
> 
> `unstable` behavior is unchanged (branch archive URL only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b154dd4ec9143ecc6fca42fc3e021ddea380831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->