### PR TITLE
8.10 Support internal-release tags in source package build

### DIFF
--- a/.github/actions/build-source-package/action.yml
+++ b/.github/actions/build-source-package/action.yml
@@ -22,9 +22,11 @@ runs:
     id: determine-version
     shell: bash
     run: |
+      # MODULES_UPDATE=1 means the tarball has no bundled modules and needs 'make modules-update'.
       if [ "${{ inputs.release_tag }}" == "unstable" ]; then
         VERSION="unstable"
         URL="https://github.com/redis/redis/archive/refs/heads/${VERSION}.tar.gz"
+        MODULES_UPDATE=1
       else
         # Version format:
         # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
@@ -38,10 +40,14 @@ runs:
         fi
         case "$HTTP_CODE" in
           2*)
+            # Public release: redis-full archive already bundles the modules.
             URL="$FULL_URL"
+            MODULES_UPDATE=0
             ;;
           404)
+            # Internal release: tag has no redis-full archive, fetch modules via 'make modules-update'.
             URL="$TAG_URL"
+            MODULES_UPDATE=1
             ;;
           *)
             echo "Unexpected HTTP status while checking $FULL_URL: $HTTP_CODE" >&2
@@ -53,6 +59,7 @@ runs:
       echo "Determined version $VERSION"
       echo "URL=${URL}"
       echo "URL=${URL}" >> $GITHUB_OUTPUT
+      echo "MODULES_UPDATE=${MODULES_UPDATE}" >> $GITHUB_ENV
   - name: Get source tarball
     shell: bash
     run: |
@@ -63,11 +70,14 @@ runs:
       mkdir -p redis-${VERSION}
       tar --extract --gunzip --file redis_${VERSION}.orig.tar.gz --strip-components=1 -C redis-${VERSION}
 
-      if [ "${{ inputs.release_tag }}" == "unstable" ]; then
-        echo "===== Pinning all bundled modules to 'master' and cloning (shallow) ====="
-        ( cd redis-${VERSION} \
-          && yq -i '.modules[].ref = "master"' modules/modules.yaml \
-          && make modules-update MODULES_UPDATE_SHALLOW=1 )
+      # Only fetch modules when needed and when this source tree defines them via modules/modules.yaml.
+      if [ "$MODULES_UPDATE" == "1" ] && [ -f redis-${VERSION}/modules/modules.yaml ]; then
+        if [ "${{ inputs.release_tag }}" == "unstable" ]; then
+          echo "===== Pinning all bundled modules to 'master' ====="
+          ( cd redis-${VERSION} && yq -i '.modules[].ref = "master"' modules/modules.yaml )
+        fi
+        echo "===== Cloning module sources (shallow) ====="
+        ( cd redis-${VERSION} && make modules-update MODULES_UPDATE_SHALLOW=1 )
         echo "===== Module sources cloned ====="
       fi
 


### PR DESCRIPTION
Internal-release tags have no redis-full archive but still need modules fetched. Add a MODULES_UPDATE flag: set for unstable and for release tags whose redis-full archive 404s (falling back to the tag archive). Run 'make modules-update' when the flag is set and the source tree has modules/modules.yaml; master pinning stays exclusive to unstable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI packaging logic only; no runtime Redis, auth, or data-path changes.
> 
> **Overview**
> The **build-source-package** composite action now decides whether bundled modules must be fetched at build time via a **`MODULES_UPDATE`** flag set during version resolution.
> 
> For **unstable**, it still uses the branch tarball and sets **`MODULES_UPDATE=1`**. For **versioned releases**, it probes **`redis-full.tar.gz`**: a successful response uses that archive and skips module cloning; a **404** treats the tag as an internal release, falls back to the tag source archive, and sets **`MODULES_UPDATE=1`**.
> 
> The build step runs **`make modules-update`** only when **`MODULES_UPDATE=1`** and **`modules/modules.yaml`** exists. Pinning module refs to **`master`** remains **unstable-only**; internal release tags clone modules without that override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9428bb5dd1aa4ba489e5c8135c1f54074c82d50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->