### PR TITLE
8.10 redis conf alignment

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+redis (6:8.10.0-1rl2~@RELEASE@1) @RELEASE@; urgency=low
+
+  * Restore the Debian defaults in the generated redis.conf: supervised auto,
+    logfile /var/log/redis/redis-server.log, dir /var/lib/redis, and pidfile
+    commented out. These were lost when conf-dist/redis.conf was dropped in
+    favour of generating the conf from upstream.
+
+ -- Redis Team <redis@redis.io>  Thu, 30 Jul 2026 14:39:23 +0300
+
 redis (6:8.10.0-1rl1~@RELEASE@1) @RELEASE@; urgency=low
 
   * Redis 8.10.0: https://github.com/redis/redis/releases/tag/8.10.0

--- a/debian/rules
+++ b/debian/rules
@@ -55,6 +55,21 @@ else
     $(warning Unsupported architecture: '$(ARCH)')
 endif
 
+# Upstream defaults assume a foreground single-instance run; restore the values
+# debian/conf-dist/redis.conf carried, matching conf-dist/sentinel.conf.
+define debianize-conf
+	sed -i \
+		-e 's|^# supervised auto$$|supervised auto|' \
+		-e 's|^pidfile /var/run/redis_6379\.pid$$|#pidfile /run/redis/redis-server.pid|' \
+		-e 's|^logfile ""$$|logfile /var/log/redis/redis-server.log|' \
+		-e 's|^dir \./$$|dir /var/lib/redis|' \
+		redis.conf
+	grep -qx 'supervised auto' redis.conf
+	grep -qx 'logfile /var/log/redis/redis-server.log' redis.conf
+	grep -qx 'dir /var/lib/redis' redis.conf
+	! grep -qx 'pidfile .*' redis.conf
+endef
+
 override_dh_auto_install:
 	debian/bin/generate-systemd-service-files
 	cp debian/conf-dist/sentinel.conf ./sentinel.conf
@@ -63,11 +78,13 @@ ifeq ($(WITH_MODULES),yes)
 	# loadmodule lines must point at the final installed path, not the staging one.
 	$(MAKE) sync-redis-conf PREFIX=/usr/lib/redis/modules ASSUME_BUILT=1
 	mv -f redis-full.conf redis.conf
+	$(debianize-conf)
 else
 	sed -i '/usr\/local\/lib\/redis\/modules\/\*\.so/d' debian/redis-server.install
 	$(MAKE) deploy redis DESTDIR=$(CURDIR)/debian/tmp PREFIX=/usr/local
 	$(MAKE) sync-redis-conf none
 	mv -f redis-full.conf redis.conf
+	$(debianize-conf)
 endif
 
 override_dh_auto_build:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Packaging-only install-time config transformation with grep guards; no runtime Redis code changes.
> 
> **Overview**
> Packaged **redis.conf** is generated from upstream again instead of `debian/conf-dist/redis.conf`, which dropped Debian-specific settings. This PR adds a **`debianize-conf`** step in **`debian/rules`** that runs after `redis-full.conf` is renamed to `redis.conf` (with and without modules).
> 
> The step **`sed`**-adjusts **`supervised auto`**, **`logfile /var/log/redis/redis-server.log`**, **`dir /var/lib/redis`**, and comments out **`pidfile`** (Debian/systemd layout), then **`grep`** checks those expectations so a bad upstream template fails the build. **`debian/changelog`** is bumped to **8.10.0-1rl2** to record the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74aac3c7008213ca4d0d195db6fc6724e075829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->